### PR TITLE
Changes devenv dependency on bazelisk to bazel and removes unnecces…

### DIFF
--- a/projects/java_greeter/devenv.nix
+++ b/projects/java_greeter/devenv.nix
@@ -4,7 +4,7 @@
 
   # https://devenv.sh/packages/
   packages = [
-    pkgs.bazelisk
+    pkgs.bazel
     pkgs.buildifier
     pkgs.buildozer
     pkgs.gcc

--- a/projects/react-cra/.bazeliskrc
+++ b/projects/react-cra/.bazeliskrc
@@ -1,1 +1,0 @@
-../bazelrc/.bazeliskrc

--- a/projects/react-cra/devenv.nix
+++ b/projects/react-cra/devenv.nix
@@ -3,11 +3,10 @@
 {
   # https://devenv.sh/packages/
   packages = [
-    pkgs.bazelisk
+    pkgs.bazel
     pkgs.buildifier
     pkgs.buildozer
     pkgs.gcc
-    pkgs.nodejs.pkgs.pnpm
     pkgs.bazel-watcher
   ];
 
@@ -18,14 +17,12 @@
     echo pnpm `pnpm --version`
     echo npm `npm --version`
     echo yarn `yarn --version`
-
-    alias bazel='bazelisk'
   '';
 
   # https://devenv.sh/languages/
   languages.javascript.enable = true;
   languages.typescript.enable = true;
-  languages.javascript.corepack.enable = true;
+  languages.javascript.corepack.enable = true;  # Adds JS related tooling like pnpm
 
   # https://devenv.sh/pre-commit-hooks/
   # pre-commit.hooks.shellcheck.enable = true;


### PR DESCRIPTION
This is a small fix to clean up some of the devenv dependencies.
Specifically it:
- changes devenv's dependency on bazelisk to bazel
- removes the now unneeded `.bazeliskrc` file from the `react-cra` project
- removes an unneccesary pnpm package declaration since pnpm is already provided when we use the following declaration: `languages.javascript.corepack.enable = true;`